### PR TITLE
fix: gallery photo rotation on upload

### DIFF
--- a/server/controllers/collectionPhotos.js
+++ b/server/controllers/collectionPhotos.js
@@ -43,6 +43,7 @@ exports.createPhoto = [
 		}
 
 		await sharp(req.file.buffer)
+			.rotate()
 			.webp({ quality: 80 })
 			.toFile(fullPath);
 


### PR DESCRIPTION
## Summary
- Adds `.rotate()` to the `sharp` pipeline in `collectionPhotos.js` to auto-orient images based on EXIF metadata
- Fixes photos from mobile devices appearing rotated in the gallery after upload

Closes #4